### PR TITLE
Fix vet profile bloc test

### DIFF
--- a/test/blocs/vet_list_bloc_test.dart
+++ b/test/blocs/vet_list_bloc_test.dart
@@ -47,9 +47,9 @@ void main() {
       expect: () => <VetProfileState>[
         const VetProfileState(status: VetProfileStatus.loading, vet: null, errorMessage: null),
         const VetProfileState(
-          status: VetProfileStatus.failure, 
-          vet: null, 
-          errorMessage: 'Ветеринар (ID: non_existent_id) табылган жок. Азыркы учурда бир гана "vet_асанова" ID\'си боюнча маалымат бар.',
+          status: VetProfileStatus.failure,
+          vet: null,
+          errorMessage: 'Ветеринар (ID: non_existent_id) табылган жок. Азыркы учурда бир гана "vet_asanov" ID\'си боюнча маалымат бар.',
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- adjust expected error string in `vet_list_bloc_test.dart`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859bfb1ca40832c834ccb24cb9f27d3